### PR TITLE
Unpack one-element tuple correctly

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -80,7 +80,7 @@ class DashBoard(Component):
             cursor = self.db.cursor()
             sql = "select name from milestone where (completed = 0) limit 0, 1"
             cursor.execute(sql)
-            for name in cursor:
+            for name, in cursor:
                 self.milestone = name
 
         if 'dev' in req.args:
@@ -271,7 +271,7 @@ class DashBoard(Component):
         sql = "select name from milestone where (name not in ('%s')) and (completed = 0)" % self.milestone
         cursor.execute(sql)
         data = []
-        for name in cursor:
+        for name, in cursor:
             data.append(name)
 
         return data


### PR DESCRIPTION
This PR fixes the following problem which occurs when the dashboard is opened:

```
2016-08-22 14:21:21,810 Trac[main] ERROR: Internal Server Error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/trac/web/main.py", line 497, in _dispatch_request
    dispatcher.dispatch(req)
  File "/usr/lib/python2.7/site-packages/trac/web/main.py", line 214, in dispatch
    resp = chosen_handler.process_request(req)
  File "/usr/lib/python2.7/site-packages/dashboard/dashboard.py", line 328, in process_request
    data['milestone_data'] = self.get_milestone_data()
  File "/usr/lib/python2.7/site-packages/dashboard/dashboard.py", line 245, in get_milestone_data
    cursor.execute(sql)
  File "/usr/lib/python2.7/site-packages/trac/db/util.py", line 66, in execute
    return self.cursor.execute(sql)
  File "/usr/lib/python2.7/site-packages/trac/db/sqlite_backend.py", line 78, in execute
    result = PyFormatCursor.execute(self, *args)
  File "/usr/lib/python2.7/site-packages/trac/db/sqlite_backend.py", line 56, in execute
    args or [])
  File "/usr/lib/python2.7/site-packages/trac/db/sqlite_backend.py", line 48, in _rollback_on_error
    return function(self, *args, **kwargs)
OperationalError: near "milestone1": syntax error
```

This error is raised because of an invalid SQL statement which looks like:

```
select count(*) as total, status from ticket where (milestone = '(u'milestone1',)') and (owner = 'admin') and (type = 'defect') group by status
```

The statement is corrupt since substituted `milestone` variable is of one-element tuple rather than string.
The direct cause came from line 83, but line 274 had the same problem.
